### PR TITLE
Fix link to OpenAI official documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Last Commit](https://img.shields.io/github/last-commit/FabrizioCafolla/openai-crawlers-ip-ranges/main)
 
-Here are the complete and updated lists of OpenAI IP addresses ([Official doc](https://platform.openai.com/docs/bots/overview-of-openai-crawlers)).
+Here are the complete and updated lists of OpenAI IP addresses ([Official doc](https://developers.openai.com/api/docs/bots/)).
 
 **Why this list?** For some time I have been receiving many requests from `user-agent` signed by OpenAI and by researching on the web I realized that I am not the only one. One way to block the bot crawl is to insert it into the `robots.txt` file but apparently this is not enough to block the page scanning.
 


### PR DESCRIPTION
Updated the link to the official OpenAI documentation. The old link was a 404 error.